### PR TITLE
Add mode and retry commands

### DIFF
--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -17,7 +17,7 @@ A complete **Discord voice recording and transcription bot** written in Go that:
 ┌─────────────────┐    ┌──────────────────┐    ┌─────────────────┐
 │   Discord Bot   │    │  Audio Pipeline  │    │ STT Processing  │
 │                 │    │                  │    │                 │
-│ • !join/!leave  │───▶│ • Opus Decoder   │───▶│ • Vosk (Local)  │
+│ • !join/!stop   │───▶│ • Opus Decoder   │───▶│ • Vosk (Local)  │
 │ • Voice Conn    │    │ • VAD Detection  │    │ • Deepgram API  │
 │ • Session Mgmt  │    │ • Audio Chunker  │    │ • Worker Pool   │
 └─────────────────┘    └──────────────────┘    └─────────────────┘
@@ -73,7 +73,7 @@ discord-notetaker/
 ## 🔧 Core Components
 
 ### 1. **Discord Bot** (`internal/bot/`)
-- **Commands**: `!join` and `!leave` 
+- **Commands**: `!join`, `!stop`, `!mode`, `!retry`
 - **Voice Connection**: Handles Discord voice channel joining/leaving
 - **Session Management**: Tracks active recording sessions per guild
 - **File Upload**: Sends transcripts and notes to Discord channels

--- a/SETUP.md
+++ b/SETUP.md
@@ -78,7 +78,9 @@
 ### Commands
 
 - `!join` - Join your current voice channel and start recording
-- `!leave` - Stop recording and generate notes
+- `!stop` - Stop recording and generate notes
+- `!mode <name>` - Change summary style
+- `!retry [mode]` - Retry summarisation with optional mode
 
 ### Example Flow
 
@@ -86,8 +88,9 @@
 2. Type `!join` in a text channel
 3. The bot joins and starts recording
 4. Have your meeting/conversation
-5. Type `!leave` when done
-6. Bot processes the audio and posts transcript + notes
+5. Type `!stop` when done
+6. Optionally run `!retry brief` (or another mode) to regenerate notes
+7. Bot processes the audio and posts transcript + notes
 
 ## Configuration Options
 

--- a/internal/bot/session.go
+++ b/internal/bot/session.go
@@ -450,7 +450,7 @@ func (vs *VoiceSession) Stop() error {
 	return nil
 }
 
-func (vs *VoiceSession) Finalize() (string, string, error) {
+func (vs *VoiceSession) Finalize(mode string) (string, string, error) {
 	vs.mutex.RLock()
 	utterances := make([]audio.Utterance, len(vs.utterances))
 	copy(utterances, vs.utterances)
@@ -511,7 +511,7 @@ func (vs *VoiceSession) Finalize() (string, string, error) {
 	// Generate and save notes
 	// Use a fresh context for summarization since the session context may be cancelled
 	summaryCtx := context.Background()
-	notes, err := vs.summariser.Summarise(summaryCtx, utterances)
+	notes, err := vs.summariser.Summarise(summaryCtx, utterances, mode)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to generate notes: %w", err)
 	}

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,9 @@ Summaries/notes are generated with **Gemini Flash** via Google’s Gen AI Go SDK
 ## Feature set
 
 - `!join` — join the caller’s voice channel, play a chime, begin capture & live partial captions (optional).
-- `!leave` — stop capture; flush outstanding chunks; post transcript + notes.
+- `!stop` — stop capture; flush outstanding chunks; post transcript + notes.
+- `!mode` — set summary style (`brief`, `verbose`, `casual`, `formal`).
+- `!retry` — regenerate notes with an optional mode.
 - Chunked processing (default **5 s** windows, overlap 300 ms) to amortize latency and enable incremental notes.
 - Diarization: per‑user tagging from Discord voice state + (optionally) STT diarization to resolve overlaps.
 - Resilience: back‑pressure on the STT worker pool, automatic reconnect, graceful shutdown.
@@ -106,10 +108,14 @@ MAX_PARALLEL_STT=4
   3. Play chime via Opus writer.
   4. Begin chunker + STT workers.
 
-- `!leave`
+- `!stop`
   1. Stop capture; close chunker; wait for workers to drain.
   2. Finalize transcript JSONL and call Gemini to produce notes.
   3. Upload transcript (`.jsonl`) and notes (`.md`) to the text channel.
+- `!mode`
+  1. Change how concise or formal the notes are.
+- `!retry`
+  1. Reprocess the latest transcript with the current or given mode.
 
 ---
 
@@ -173,7 +179,7 @@ go mod tidy
 GOOS=$(go env GOOS) GOARCH=$(go env GOARCH) go run ./cmd/discord-notetaker
 ```
 
-Invite bot and use `!join` / `!leave` in a text channel.
+Invite bot and use `!join` / `!stop` in a text channel. Use `!help` for all commands.
 
 ---
 


### PR DESCRIPTION
## Summary
- add summarisation modes and retry capability
- replace `!leave` with `!stop`
- support `!mode`, `!retry`, and `!help`
- record last session transcripts for retries
- document updated commands

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6886062231848332aa4a2c3a0aea3fc5